### PR TITLE
Fix up bucket usage to actually work

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ CHANGELOG
 
 --------------------
 
+## 1.1.2 (12-21-2015)
+
+* @bdeitte Fix up Buckets usage, which was not working quite right until now.
+
 ## 1.1.1 (12-21-2015)
 
 * @bdeitte More docs

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library tries to look like a subset of the API from [AWS.S3](http://docs.aw
 Before using this library, you should have two buckets set up for cross-region replication.  They need to be both replicating to each other.  See [Amazon's guide for setup](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr-how-setup.html).  A few additional tips on setup:
 - don't forget to turn on versioning for both buckets
 - once you have gone through the replication steps, remember to go back to setting up the second bucket for replication as well
-- if you are starting with one bucket that arleady has data, make sure to use the AWS SDK for an initial copy of files from one bucket to another
+- if you are starting with one bucket that already has data, make sure to use the AWS SDK for an initial copy of files from one bucket to another
 
 Once you have two buckets to use, you can set up s3-s3 in your code by first setting up the two buckets using [aws-sdk](https://aws.amazon.com/sdk-for-node-js/) in the normal way you would set them up.  Something like:
 
@@ -31,12 +31,10 @@ Once you have two buckets to use, you can set up s3-s3 in your code by first set
     s3Secondary = new AWS.S3(awsSecondaryConfig);
 ```
 
-Make sure the configurations used above contain a bucket.  Sometimes this is specified later, in params, but for this library it must be specified up front.
-
 With the above, you can then set up the s3-s3 object:
 ```
   var S3S3 = require('s3-s3'),
-    s3 = new S3S3(s3Primary, s3Secondary);
+    s3 = new S3S3(s3Primary, primaryBucketName, s3Secondary, secondaryBucketName);
 ```
 
 You can then use s3 to make many of the same calls that you would make with AWS.S3:
@@ -60,7 +58,10 @@ You can then use s3 to make many of the same calls that you would make with AWS.
   }).send();
 ```
 
-Two things to note about the example above.  The first is that using the request object returned from an API call is required with this library.  AWS.S3 also allows you to pass in parameters to putObject above, and that is not a current feature of this library.  The second thing to note is the failover event used above- this is the one addition to the normal event list returned from AWS.S3.  It is used to indicate that a failover to the secondary location is being attempted due to issues communicating with the primary location.
+A few things to note about the example above:
+1. Using the request object returned from an API call is required with this library.  AWS.S3 also allows you to pass in parameters to putObject above, and that is not a current feature of this library.
+2. 'Bucket' is usually given in request.params.  This can not be done using this library.  You always specify the buckets when initializing s3-s3.
+3. The failover event used above is the one addition to the normal event list returned from AWS.S3.  It is used to indicate that a failover to the secondary location is being attempted due to issues communicating with the primary location.
 
 ## APIs
 
@@ -68,7 +69,7 @@ New s3-s3 object:
 
 ```
   var S3S3 = require('s3-s3'),
-    s3 = new S3S3(s3Primary, s3Secondary);
+    s3 = new S3S3(new AWS.S3(awsConfig), primaryBucketName, new AWS.S3(secondaryConfig), secondaryBucketName);
 ```
 
 S3 APIs:

--- a/lib/s3-s3.js
+++ b/lib/s3-s3.js
@@ -6,7 +6,13 @@
 
 // Used in module.exports below, this function mimics AWS.S3.  You must pass in a primary
 // AWS.S3 object and secondary/failover AWS.S3 object
-var s3 = function (primaryS3, secondaryS3) {
+var s3 = function (primaryS3, primaryBucket, secondaryS3, secondaryBucket) {
+
+  if (! primaryS3 || ! primaryBucket || ! secondaryS3 || ! secondaryBucket) {
+    throw new Error('You must specify all of the following when setting up s3-s3 ' +
+      'for it to work properly: primaryS3, primaryBucket, secondaryS3, secondaryBucket');
+  }
+
   var
     // Request object that proxies to the real AWS.Request object, which can be found in realRequest.
     // If a secondary location needs to be used, a new AWS.Request object is created from
@@ -46,9 +52,15 @@ var s3 = function (primaryS3, secondaryS3) {
           if (this.hasOwnProperty('params')) {
             if (this.params.hasOwnProperty('Bucket')) {
               throw new Error('The Bucket parameter can not be used on request.' +
-                'Specify the buckets needed in the configs passed to s3-s3 instead.');
+                'Specify the buckets in the configs passed to s3-s3 instead.');
             }
             realRequest.params = this.params;
+            if (usingPrimary) {
+              realRequest.params.Bucket = primaryBucket;
+            }
+	    else {
+              realRequest.params.Bucket = secondaryBucket;
+	    }
           }
 
           // add on() calls on the real request object, and use the stored on() callbacks

--- a/test/s3-s3.js
+++ b/test/s3-s3.js
@@ -85,7 +85,7 @@ describe('s3-s3', function() {
     it('should call success after putObject send', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.putObject();
 
       assert.ok(request !== null);
@@ -101,7 +101,7 @@ describe('s3-s3', function() {
     it('should call success after deleteObject send', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.deleteObject();
 
       assert.ok(request !== null);
@@ -117,7 +117,7 @@ describe('s3-s3', function() {
     it('should call success after deleteObjects send', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.deleteObjects();
 
       assert.ok(request !== null);
@@ -133,7 +133,7 @@ describe('s3-s3', function() {
     it('should call success after listObjects send', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.listObjects();
 
       assert.ok(request !== null);
@@ -149,7 +149,7 @@ describe('s3-s3', function() {
     it('should call success after getObject send', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.getObject();
 
       assert.ok(request !== null);
@@ -165,7 +165,7 @@ describe('s3-s3', function() {
     it('should call error after putObject send failure', function(done) {
       var primaryMock = mockS3({error: true }),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.putObject();
 
       assert.ok(request !== null);
@@ -185,7 +185,7 @@ describe('s3-s3', function() {
     it('should call retry after putObject send retry', function(done) {
       var primaryMock = mockS3({retry: true }),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.putObject();
 
       assert.ok(request !== null);
@@ -211,7 +211,7 @@ describe('s3-s3', function() {
     it('should fail if getObject given args', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock);
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2');
       try {
         var request = s3.getObject({});
       }
@@ -219,10 +219,11 @@ describe('s3-s3', function() {
         done();
       }
     });
+
     it('should error when an unknown on type is used', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.deleteObject();
 
       try {
@@ -233,10 +234,11 @@ describe('s3-s3', function() {
         done();
       }
     });
-    it('should error when a Bucket paraaeter is used', function(done) {
+
+    it('should error when a Bucket parameter is used', function(done) {
       var primaryMock = mockS3(),
         secondaryMock = mockS3(),
-        s3 = new S3S3(primaryMock, secondaryMock),
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
         request = s3.deleteObject();
         request.params = { Bucket: 'bucket' };
 
@@ -247,13 +249,27 @@ describe('s3-s3', function() {
         done();
       }
     });
+
+    it('should error when not all parameters are given', function(done) {
+      var primaryMock = mockS3(),
+        secondaryMock = mockS3(),
+        s3;
+
+      try {
+        s3 = new S3S3(primaryMock, 'bucket1', secondaryMock);
+      }
+      catch (err) {
+        done();
+      }
+    });
+
   });
 
   describe('failover', function() {
     it('should failover to secondary after deleteObject send issues', function(done) {
         var primaryMock = mockS3({error500: true }),
           secondaryMock = mockS3(),
-          s3 = new S3S3(primaryMock, secondaryMock),
+          s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
           request = s3.deleteObject(),
           calledFailover = false;
 
@@ -281,7 +297,7 @@ describe('s3-s3', function() {
       it('should error after deleteObject send issues with primary and secondary', function(done) {
         var primaryMock = mockS3({error500: true }),
           secondaryMock = mockS3({error500: true }),
-          s3 = new S3S3(primaryMock, secondaryMock),
+          s3 = new S3S3(primaryMock, 'bucket1', secondaryMock, 'bucket2'),
           request = s3.deleteObject();
 
         assert.ok(request !== null);


### PR DESCRIPTION
Now that Bucket can't be specified in request.params, I see that Bucket is not really on an AWS config.  Switch things around to add new params to account for this.
