### PR TITLE
Fix error that occurred during failover 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ CHANGELOG
 
 --------------------
 
+## 1.1.2 (12-26-2015)
+
+* @bdeitte Fix error that occurred during failover due to copying params.
+
 ## 1.1.2 (12-21-2015)
 
 * @bdeitte Fix up Buckets usage, which was not working quite right until now.

--- a/lib/s3-s3.js
+++ b/lib/s3-s3.js
@@ -50,7 +50,7 @@ var s3 = function (primaryS3, primaryBucket, secondaryS3, secondaryBucket) {
           var that = this;
 
           if (this.hasOwnProperty('params')) {
-            if (this.params.hasOwnProperty('Bucket')) {
+            if (usingPrimary && this.params.hasOwnProperty('Bucket')) {
               throw new Error('The Bucket parameter can not be used on request.' +
                 'Specify the buckets in the configs passed to s3-s3 instead.');
             }


### PR DESCRIPTION
We should only check the params the first time through, since they are then copied to the real request and have the Bucket added (making them fail the check on the failover)
